### PR TITLE
improve rss/atom feed subscription

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -24,6 +24,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c99f64d1e06488f620f932677e24bc6e2897582980441ae90a671415bd7ec2f"
 dependencies = [
  "cfg-if",
+ "getrandom 0.2.10",
  "once_cell",
  "version_check",
 ]
@@ -514,6 +515,7 @@ dependencies = [
  "reqwest",
  "rss",
  "rusqlite",
+ "scraper",
  "sea-query",
  "sea-query-rusqlite",
  "serde",
@@ -657,6 +659,19 @@ dependencies = [
  "quote",
  "smallvec",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "cssparser"
+version = "0.31.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b3df4f93e5fbbe73ec01ec8d3f68bba73107993a5b1e7519273c32db9b0d5be"
+dependencies = [
+ "cssparser-macros",
+ "dtoa-short",
+ "itoa 1.0.9",
+ "phf 0.10.1",
+ "smallvec",
 ]
 
 [[package]]
@@ -885,6 +900,12 @@ name = "dunce"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56ce8c6da7551ec6c462cbaf3bfbc75131ebbfa1c944aeaa9dab51ca1c5f0c3b"
+
+[[package]]
+name = "ego-tree"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a68a4904193147e0a8dec3314640e6db742afd5f6e634f428a6af230d9b3591"
 
 [[package]]
 name = "embed-resource"
@@ -1282,6 +1303,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "getopts"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14dbbfd5c71d70241ecf9e6f13737f7b5ce823821063188d7e46c41d371eebd5"
+dependencies = [
+ "unicode-width",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1548,7 +1578,21 @@ checksum = "e5c13fb08e5d4dfc151ee5e88bae63f7773d61852f3bdc73c9f4b9e1bde03148"
 dependencies = [
  "log",
  "mac",
- "markup5ever",
+ "markup5ever 0.10.1",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "html5ever"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bea68cab48b8459f17cf1c944c67ddc572d272d9f2b274140f223ecb1da4a3b7"
+dependencies = [
+ "log",
+ "mac",
+ "markup5ever 0.11.0",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
@@ -1860,10 +1904,10 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ea8e9c6e031377cff82ee3001dc8026cdf431ed4e2e6b51f98ab8c73484a358"
 dependencies = [
- "cssparser",
- "html5ever",
+ "cssparser 0.27.2",
+ "html5ever 0.25.2",
  "matches",
- "selectors",
+ "selectors 0.22.0",
 ]
 
 [[package]]
@@ -1977,7 +2021,21 @@ checksum = "a24f40fb03852d1cdd84330cddcaf98e9ec08a7b7768e952fad3b4cf048ec8fd"
 dependencies = [
  "log",
  "phf 0.8.0",
- "phf_codegen",
+ "phf_codegen 0.8.0",
+ "string_cache",
+ "string_cache_codegen",
+ "tendril",
+]
+
+[[package]]
+name = "markup5ever"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a2629bb1404f3d34c2e921f21fd34ba00b206124c81f65c50b43b6aaefeb016"
+dependencies = [
+ "log",
+ "phf 0.10.1",
+ "phf_codegen 0.10.0",
  "string_cache",
  "string_cache_codegen",
  "tendril",
@@ -2430,6 +2488,16 @@ checksum = "cbffee61585b0411840d3ece935cce9cb6321f01c45477d30066498cd5e1a815"
 dependencies = [
  "phf_generator 0.8.0",
  "phf_shared 0.8.0",
+]
+
+[[package]]
+name = "phf_codegen"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fb1c3a8bc4dd4e5cfce29b44ffc14bedd2ee294559a294e2a4d4c9e9a6a13cd"
+dependencies = [
+ "phf_generator 0.10.0",
+ "phf_shared 0.10.0",
 ]
 
 [[package]]
@@ -3006,6 +3074,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
+name = "scraper"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "585480e3719b311b78a573db1c9d9c4c1f8010c2dee4cc59c2efe58ea4dbc3e1"
+dependencies = [
+ "ahash",
+ "cssparser 0.31.2",
+ "ego-tree",
+ "getopts",
+ "html5ever 0.26.0",
+ "once_cell",
+ "selectors 0.25.0",
+ "tendril",
+]
+
+[[package]]
 name = "sea-query"
 version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3069,17 +3153,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df320f1889ac4ba6bc0cdc9c9af7af4bd64bb927bccdf32d81140dc1f9be12fe"
 dependencies = [
  "bitflags 1.3.2",
- "cssparser",
+ "cssparser 0.27.2",
  "derive_more",
  "fxhash",
  "log",
  "matches",
  "phf 0.8.0",
- "phf_codegen",
+ "phf_codegen 0.8.0",
  "precomputed-hash",
- "servo_arc",
+ "servo_arc 0.1.1",
  "smallvec",
  "thin-slice",
+]
+
+[[package]]
+name = "selectors"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4eb30575f3638fc8f6815f448d50cb1a2e255b0897985c8c59f4d37b72a07b06"
+dependencies = [
+ "bitflags 2.4.0",
+ "cssparser 0.31.2",
+ "derive_more",
+ "fxhash",
+ "log",
+ "new_debug_unreachable",
+ "phf 0.10.1",
+ "phf_codegen 0.10.0",
+ "precomputed-hash",
+ "servo_arc 0.3.0",
+ "smallvec",
 ]
 
 [[package]]
@@ -3212,6 +3315,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98238b800e0d1576d8b6e3de32827c2d74bee68bb97748dcf5071fb53965432"
 dependencies = [
  "nodrop",
+ "stable_deref_trait",
+]
+
+[[package]]
+name = "servo_arc"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d036d71a959e00c77a63538b90a6c2390969f9772b096ea837205c6bd0491a44"
+dependencies = [
  "stable_deref_trait",
 ]
 
@@ -3680,7 +3792,7 @@ dependencies = [
  "dunce",
  "glob",
  "heck 0.4.1",
- "html5ever",
+ "html5ever 0.25.2",
  "infer",
  "json-patch",
  "kuchiki",
@@ -4029,6 +4141,12 @@ name = "unicode-segmentation"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1dd624098567895118886609431a7c3b8f516e41d30e0643f03d94592a147e36"
+
+[[package]]
+name = "unicode-width"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e51733f11c9c4f72aa0c160008246859e340b00807569a0da0e7a1079b27ba85"
 
 [[package]]
 name = "url"
@@ -4631,7 +4749,7 @@ dependencies = [
  "gio",
  "glib",
  "gtk",
- "html5ever",
+ "html5ever 0.25.2",
  "http",
  "kuchiki",
  "libc",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -26,6 +26,7 @@ reqwest = { version = "0.11", features = ["blocking"] }
 sha1_smol = { version = "1", features = ["std"] }
 thiserror = "1.0"
 regex = "1.9"
+scraper = "0.18.1"
 
 [dev-dependencies]
 pretty_assertions = "1.4"

--- a/src-tauri/src/commands/feeds.rs
+++ b/src-tauri/src/commands/feeds.rs
@@ -22,6 +22,7 @@ pub fn create_feed(db_state: State<DbState>, arg: FeedToCreate) -> Result<String
     let arg = FeedToCreate {
         title,
         link: arg.link,
+        fetch_old_items: arg.fetch_old_items,
     };
 
     match feeds::create(&db, &arg) {

--- a/src-tauri/src/commands/feeds.rs
+++ b/src-tauri/src/commands/feeds.rs
@@ -28,12 +28,10 @@ pub fn create_feed(db_state: State<DbState>, arg: FeedToCreate) -> Result<String
 
     let link = if is_feed {
         arg.link.clone()
+    } else if let Some(rss_link) = find_feed_link(&html_content).unwrap() {
+        rss_link
     } else {
-        if let Some(rss_link) = find_feed_link(&html_content).unwrap() {
-            rss_link
-        } else {
-            return Err(Error::InvalidFeedLink(arg.link).to_string());
-        }
+        return Err(Error::InvalidFeedLink(arg.link).to_string());
     };
 
     let title = match fetch_feed_title(&link, proxy.as_deref()) {

--- a/src-tauri/src/commands/feeds.rs
+++ b/src-tauri/src/commands/feeds.rs
@@ -1,14 +1,11 @@
-use std::str::FromStr;
-
 use tauri::State;
 
 use crate::models::settings;
 use crate::models::settings::SettingKey;
-use crate::syndication::find_feed_link;
 use crate::{
     models::feeds::{self, Feed, FeedToCreate, FeedToUpdate},
     producer::create_new_items,
-    syndication::{self, fetch_feed_title, fetch_content},
+    syndication::{fetch_feed_title, fetch_content, find_feed_link, is_feed},
     DbState,
 };
 
@@ -19,8 +16,7 @@ pub fn create_feed(db_state: State<DbState>, arg: FeedToCreate) -> Result<String
         .map(|x| x.value)
         .ok();
 
-    let is_rss_link = syndication::Feed::from_str(&arg.link).is_ok();
-    let link = if is_rss_link {
+    let link = if is_feed(&arg.link, proxy.as_deref()).unwrap() {
         arg.link.clone()
     } else {
         let html_content = fetch_content(&arg.link, proxy.as_deref()).unwrap();

--- a/src-tauri/src/commands/feeds.rs
+++ b/src-tauri/src/commands/feeds.rs
@@ -5,7 +5,7 @@ use crate::models::settings::SettingKey;
 use crate::{
     models::feeds::{self, Feed, FeedToCreate, FeedToUpdate},
     producer::create_new_items,
-    syndication::{fetch_feed_title, fetch_content, find_feed_link, is_feed},
+    syndication::{fetch_content, fetch_feed_title, find_feed_link, is_feed},
     DbState,
 };
 

--- a/src-tauri/src/commands/feeds.rs
+++ b/src-tauri/src/commands/feeds.rs
@@ -11,6 +11,10 @@ use crate::{
 
 #[tauri::command]
 pub fn create_feed(db_state: State<DbState>, arg: FeedToCreate) -> Result<String, String> {
+    if arg.link.is_empty() {
+        return Err("Link cannot be empty".to_string());
+    }
+
     let db = db_state.db.lock().unwrap();
     let proxy = settings::read(&db, &SettingKey::Proxy)
         .map(|x| x.value)

--- a/src-tauri/src/commands/feeds.rs
+++ b/src-tauri/src/commands/feeds.rs
@@ -9,10 +9,12 @@ use crate::{
     DbState,
 };
 
+use crate::error::Error;
+
 #[tauri::command]
 pub fn create_feed(db_state: State<DbState>, arg: FeedToCreate) -> Result<String, String> {
     if arg.link.is_empty() {
-        return Err("Link cannot be empty".to_string());
+        return Err(Error::EmptyString.to_string());
     }
 
     let db = db_state.db.lock().unwrap();
@@ -29,7 +31,7 @@ pub fn create_feed(db_state: State<DbState>, arg: FeedToCreate) -> Result<String
             rss_link
         } else {
             // TODO: Notification when RSS feeds cannot be fetched?
-            return Err("No valid RSS/Atom link found".to_string());
+            return Err(Error::InvalidFeedLink(arg.link).to_string());
         }
     };
 

--- a/src-tauri/src/error.rs
+++ b/src-tauri/src/error.rs
@@ -8,11 +8,17 @@ pub enum Error {
     #[error("invalid key `{0}` for `{1}`")]
     InvalidEnumKey(String, String),
 
+    #[error("invalid feed link `{0}`")]
+    InvalidFeedLink(String),
+
     #[error("forbidden")]
     Forbidden,
 
     #[error("failed to parse syndication feed")]
     SyndicationParsingFailure,
+
+    #[error("empty string")]
+    EmptyString,
 
     #[error("unknown")]
     Unknown,

--- a/src-tauri/src/models/database.rs
+++ b/src-tauri/src/models/database.rs
@@ -16,6 +16,7 @@ pub enum Feeds {
     Link,
     Status,
     CheckedAt,
+    FetchOldItems,
 }
 
 #[derive(Iden)]
@@ -65,6 +66,12 @@ pub fn migrate(db: &Connection) -> Result<()> {
                 .default("subscribed"),
         )
         .col(ColumnDef::new(Feeds::CheckedAt).date_time().not_null())
+        .col(
+            ColumnDef::new(Feeds::FetchOldItems)
+                .boolean()
+                .not_null()
+                .default(true),
+        )
         .index(
             Index::create()
                 .unique()
@@ -147,6 +154,7 @@ pub fn migrate(db: &Connection) -> Result<()> {
     let _ = insert_settings(db, "theme", "system");
     let _ = insert_settings(db, "items_order", "ReceivedDateDesc");
     let _ = insert_settings(db, "proxy", "");
+    let _ = insert_settings(db, "fetch_old_items", "1");
 
     Ok(())
 }

--- a/src-tauri/src/models/database.rs
+++ b/src-tauri/src/models/database.rs
@@ -156,6 +156,34 @@ pub fn migrate(db: &Connection) -> Result<()> {
     let _ = insert_settings(db, "proxy", "");
     let _ = insert_settings(db, "fetch_old_items", "1");
 
+    // Add fetch_old_items column to feeds table if it doesn't exist
+    // 0.1.7 and earlier of the database doesn't have this column
+    let mut table_info = db.prepare("PRAGMA table_info(feeds)")?;
+    let mut rows = table_info.query([])?;
+
+    let mut has_fetch_old_items_column = false;
+    while let Some(row) = rows.next()? {
+        let name: String = row.get(1)?;
+        if name == "fetch_old_items" {
+            has_fetch_old_items_column = true;
+            break;
+        }
+    }
+
+    if !has_fetch_old_items_column {
+        let add_column = Table::alter()
+            .table(Feeds::Table)
+            .add_column(
+                ColumnDef::new(Feeds::FetchOldItems)
+                    .boolean()
+                    .not_null()
+                    .default(true),
+            )
+            .build(SqliteQueryBuilder);
+
+        db.execute(&add_column, [])?;
+    }
+
     Ok(())
 }
 

--- a/src-tauri/src/models/items.rs
+++ b/src-tauri/src/models/items.rs
@@ -64,6 +64,10 @@ pub struct Item {
 }
 
 impl Item {
+    pub fn id(&self) -> i32 {
+        self.id
+    }
+    
     pub fn published_at(&self) -> Option<DateTime<FixedOffset>> {
         Some(self.published_at)
     }

--- a/src-tauri/src/models/items.rs
+++ b/src-tauri/src/models/items.rs
@@ -63,6 +63,12 @@ pub struct Item {
     feed: ItemFeed,
 }
 
+impl Item {
+    pub fn published_at(&self) -> Option<DateTime<FixedOffset>> {
+        Some(self.published_at)
+    }
+}
+
 impl From<&Row<'_>> for Item {
     fn from(row: &Row) -> Self {
         Self {

--- a/src-tauri/src/models/items.rs
+++ b/src-tauri/src/models/items.rs
@@ -51,26 +51,16 @@ pub struct ItemFeed {
 
 #[derive(Serialize, Debug)]
 pub struct Item {
-    id: i32,
-    fingerprint: String,
-    author: Option<String>,
-    title: String,
-    description: String,
-    link: String,
-    status: ItemStatus,
-    is_saved: bool,
-    published_at: DateTime<FixedOffset>,
-    feed: ItemFeed,
-}
-
-impl Item {
-    pub fn id(&self) -> i32 {
-        self.id
-    }
-
-    pub fn published_at(&self) -> Option<DateTime<FixedOffset>> {
-        Some(self.published_at)
-    }
+    pub id: i32,
+    pub fingerprint: String,
+    pub author: Option<String>,
+    pub title: String,
+    pub description: String,
+    pub link: String,
+    pub status: ItemStatus,
+    pub is_saved: bool,
+    pub published_at: DateTime<FixedOffset>,
+    pub feed: ItemFeed,
 }
 
 impl From<&Row<'_>> for Item {

--- a/src-tauri/src/models/items.rs
+++ b/src-tauri/src/models/items.rs
@@ -67,7 +67,7 @@ impl Item {
     pub fn id(&self) -> i32 {
         self.id
     }
-    
+
     pub fn published_at(&self) -> Option<DateTime<FixedOffset>> {
         Some(self.published_at)
     }

--- a/src-tauri/src/models/items.rs
+++ b/src-tauri/src/models/items.rs
@@ -44,9 +44,9 @@ impl FromStr for ItemStatus {
 
 #[derive(Serialize, Debug)]
 pub struct ItemFeed {
-    id: i32,
-    title: String,
-    link: String,
+    pub id: i32,
+    pub title: String,
+    pub link: String,
 }
 
 #[derive(Serialize, Debug)]

--- a/src-tauri/src/models/settings.rs
+++ b/src-tauri/src/models/settings.rs
@@ -22,6 +22,7 @@ pub enum SettingKey {
     Theme,
     ItemsOrder,
     Proxy,
+    FetchOldItems,
 }
 
 impl Display for SettingKey {
@@ -33,6 +34,7 @@ impl Display for SettingKey {
             Self::Theme => write!(f, "theme"),
             Self::ItemsOrder => write!(f, "items_order"),
             Self::Proxy => write!(f, "proxy"),
+            Self::FetchOldItems => write!(f, "fetch_old_items"),
         }
     }
 }
@@ -48,6 +50,7 @@ impl FromStr for SettingKey {
             "theme" => Ok(Self::Theme),
             "items_order" => Ok(Self::ItemsOrder),
             "proxy" => Ok(Self::Proxy),
+            "fetch_old_items" => Ok(Self::FetchOldItems),
             _ => Err(Error::InvalidEnumKey(
                 x.to_string(),
                 "SettingKey".to_string(),
@@ -114,7 +117,7 @@ pub fn update(db: &Connection, arg: &SettingToUpdate) -> Result<usize> {
                 return Err(Error::Unknown);
             }
         }
-        SettingKey::Notification => {
+        SettingKey::Notification | SettingKey::FetchOldItems => {
             if arg.value.parse::<bool>().unwrap_or(false) {
                 return Err(Error::Unknown);
             }

--- a/src-tauri/src/producer.rs
+++ b/src-tauri/src/producer.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use chrono::{Utc, FixedOffset, DateTime};
+use chrono::{DateTime, FixedOffset, Utc};
 use rusqlite::Connection;
 
 use crate::models::feeds::FeedStatus;

--- a/src-tauri/src/producer.rs
+++ b/src-tauri/src/producer.rs
@@ -43,7 +43,7 @@ fn get_links_to_check(db: &Connection) -> Vec<(i32, String, bool)> {
                         fetch_old_items: Some(x.fetch_old_items),
                     }),
                 );
-                (x.id, x.link.clone(), x.fetch_old_items.clone())
+                (x.id, x.link.clone(), x.fetch_old_items)
             })
             .collect()
     } else {

--- a/src-tauri/src/producer.rs
+++ b/src-tauri/src/producer.rs
@@ -109,8 +109,8 @@ fn get_most_recent_items(db: &Connection) -> HashMap<i32, DateTime<FixedOffset>>
 
     let mut most_recent_items = HashMap::new();
     for row in rows {
-        let feed = row.id();
-        let published_at = row.published_at().unwrap();
+        let feed = row.id;
+        let published_at = row.published_at;
         most_recent_items.insert(feed, published_at);
     }
 

--- a/src-tauri/src/producer.rs
+++ b/src-tauri/src/producer.rs
@@ -16,13 +16,12 @@ use crate::{
 pub fn create_new_items(db: &Connection, proxy: Option<&str>) -> Vec<ItemToCreate> {
     let pairs = get_links_to_check(db);
 
-    let most_recent_items = get_most_recent_items(db);
-
     let mut inserted = vec![];
     for (feed, link, fetch_old_items) in pairs {
         let mut items = fetch_feed_items(&link, proxy).unwrap();
 
         if !fetch_old_items {
+            let most_recent_items = get_most_recent_items(db);
             if let Some(most_recent) = most_recent_items.get(&feed) {
                 items.retain(|item| {
                     item.published_at

--- a/src-tauri/src/producer.rs
+++ b/src-tauri/src/producer.rs
@@ -30,10 +30,9 @@ pub fn create_new_items(db: &Connection, proxy: Option<&str>) -> Vec<ItemToCreat
             } else {
                 items.truncate(1)
             }
-        } else {
-            items.sort_by_key(|x| x.published_at);
         }
 
+        items.sort_by_key(|x| x.published_at);
         inserted.extend(insert_new_items(db, feed, &items));
     }
 
@@ -109,7 +108,7 @@ fn get_most_recent_items(db: &Connection) -> HashMap<i32, DateTime<FixedOffset>>
 
     let mut most_recent_items = HashMap::new();
     for row in rows {
-        let feed = row.id;
+        let feed = row.feed.id;
         let published_at = row.published_at;
         most_recent_items.insert(feed, published_at);
     }

--- a/src-tauri/src/syndication.rs
+++ b/src-tauri/src/syndication.rs
@@ -20,7 +20,9 @@ pub fn is_feed(link: &str, proxy: Option<&str>) -> Result<bool> {
 
 pub fn find_feed_link(html_content: &str) -> Result<Option<String>> {
     let document = Html::parse_document(html_content);
-    let selector = Selector::parse("link[type='application/rss+xml'], link[type='application/atom+xml']").unwrap();
+    let selector =
+        Selector::parse("link[type='application/rss+xml'], link[type='application/atom+xml']")
+            .unwrap();
 
     for element in document.select(&selector) {
         if let Some(href) = element.value().attr("href") {
@@ -39,10 +41,7 @@ pub fn fetch_feed_title(link: &str, proxy: Option<&str>) -> Result<String> {
     }
 }
 
-pub fn fetch_feed_items(
-    link: &str,
-    proxy: Option<&str>
-) -> Result<Vec<RawItem>> {
+pub fn fetch_feed_items(link: &str, proxy: Option<&str>) -> Result<Vec<RawItem>> {
     let content = fetch_content(link, proxy)?;
     match content.parse::<Feed>()? {
         Feed::Atom(atom) => Ok(atom

--- a/src-tauri/src/syndication.rs
+++ b/src-tauri/src/syndication.rs
@@ -13,6 +13,11 @@ pub struct RawItem {
     pub published_at: Option<DateTime<FixedOffset>>,
 }
 
+pub fn is_feed(link: &str, proxy: Option<&str>) -> Result<bool> {
+    let content = fetch_content(link, proxy)?;
+    Ok(content.parse::<Feed>().is_ok())
+}
+
 pub fn find_feed_link(html_content: &str) -> Result<Option<String>> {
     let document = Html::parse_document(html_content);
     let selector = Selector::parse("link[type='application/rss+xml'], link[type='application/atom+xml']").unwrap();

--- a/src-tauri/src/syndication.rs
+++ b/src-tauri/src/syndication.rs
@@ -41,12 +41,11 @@ pub fn fetch_feed_title(link: &str, proxy: Option<&str>) -> Result<String> {
 
 pub fn fetch_feed_items(
     link: &str,
-    proxy: Option<&str>,
-    fetch_old_items: bool,
+    proxy: Option<&str>
 ) -> Result<Vec<RawItem>> {
     let content = fetch_content(link, proxy)?;
-    let mut items: Vec<RawItem> = match content.parse::<Feed>()? {
-        Feed::Atom(atom) => atom
+    match content.parse::<Feed>()? {
+        Feed::Atom(atom) => Ok(atom
             .entries()
             .iter()
             .map(|x| RawItem {
@@ -66,8 +65,8 @@ pub fn fetch_feed_items(
                     .map(|x| x.unwrap().to_string()),
                 published_at: x.published().map(|x| x.with_timezone(&Utc).fixed_offset()),
             })
-            .collect(),
-        Feed::RSS(rss) => rss
+            .collect()),
+        Feed::RSS(rss) => Ok(rss
             .items()
             .iter()
             .map(|x| RawItem {
@@ -87,15 +86,8 @@ pub fn fetch_feed_items(
                     .filter(std::result::Result::is_ok)
                     .map(std::result::Result::unwrap),
             })
-            .collect(),
-    };
-
-    if !fetch_old_items {
-        items.sort_by(|a, b| b.published_at.cmp(&a.published_at));
-        items.truncate(1);
+            .collect()),
     }
-
-    Ok(items)
 }
 
 #[cfg(test)]

--- a/src-tauri/src/syndication.rs
+++ b/src-tauri/src/syndication.rs
@@ -13,11 +13,6 @@ pub struct RawItem {
     pub published_at: Option<DateTime<FixedOffset>>,
 }
 
-pub fn is_feed(link: &str, proxy: Option<&str>) -> Result<bool> {
-    let content = fetch_content(link, proxy)?;
-    Ok(content.parse::<Feed>().is_ok())
-}
-
 pub fn find_feed_link(html_content: &str) -> Result<Option<String>> {
     let document = Html::parse_document(html_content);
     let selector =

--- a/src-tauri/src/tests/syndication.rs
+++ b/src-tauri/src/tests/syndication.rs
@@ -26,7 +26,8 @@ fn fetch_feed_title_atom() {
 
 #[test]
 fn fetch_feed_items_rss() {
-    let items = syndication::fetch_feed_items(&fixture("hnrss-org-frontpage.rss"), None).unwrap();
+    let items =
+        syndication::fetch_feed_items(&fixture("hnrss-org-frontpage.rss"), None, true).unwrap();
     assert_eq!(
         vec![
             RawItem {
@@ -57,7 +58,8 @@ fn fetch_feed_items_rss() {
 
 #[test]
 fn fetch_feed_items_atom() {
-    let items = syndication::fetch_feed_items(&fixture("hnrss-org-frontpage.atom"), None).unwrap();
+    let items =
+        syndication::fetch_feed_items(&fixture("hnrss-org-frontpage.atom"), None, true).unwrap();
     assert_eq!(
         vec![
             RawItem {

--- a/src-tauri/src/tests/syndication.rs
+++ b/src-tauri/src/tests/syndication.rs
@@ -26,8 +26,7 @@ fn fetch_feed_title_atom() {
 
 #[test]
 fn fetch_feed_items_rss() {
-    let items =
-        syndication::fetch_feed_items(&fixture("hnrss-org-frontpage.rss"), None, true).unwrap();
+    let items = syndication::fetch_feed_items(&fixture("hnrss-org-frontpage.rss"), None).unwrap();
     assert_eq!(
         vec![
             RawItem {
@@ -58,8 +57,7 @@ fn fetch_feed_items_rss() {
 
 #[test]
 fn fetch_feed_items_atom() {
-    let items =
-        syndication::fetch_feed_items(&fixture("hnrss-org-frontpage.atom"), None, true).unwrap();
+    let items = syndication::fetch_feed_items(&fixture("hnrss-org-frontpage.atom"), None).unwrap();
     assert_eq!(
         vec![
             RawItem {

--- a/src/api/feeds.ts
+++ b/src/api/feeds.ts
@@ -11,11 +11,13 @@ export interface Feed {
     link: string,
     status: FeedStatus,
     checked_at: string,
+    fetch_old_items: boolean,
 }
 
 export interface FeedToCreate {
     title: string,
     link: string,
+    fetch_old_items: boolean,
 }
 
 export interface FeedToUpdate {
@@ -23,6 +25,7 @@ export interface FeedToUpdate {
     title?: string | null,
     link?: string | null,
     status?: FeedStatus | null,
+    fetch_old_items?: boolean | null,
 }
 
 export async function createFeed(arg: FeedToCreate) {

--- a/src/api/settings.ts
+++ b/src/api/settings.ts
@@ -6,7 +6,8 @@ export enum SettingKey {
   DB_SCHEME_VERSION = "DbSchemeVersion",
   THEME = "Theme",
   ITEMS_ORDER = "ItemsOrder",
-  PROXY="Proxy"
+  PROXY="Proxy",
+  FETCH_OLD_ITEMS = "FetchOldItems"
 }
 
 export interface Setting {

--- a/src/routes/Settings.tsx
+++ b/src/routes/Settings.tsx
@@ -19,6 +19,7 @@ function Settings() {
     [api.SettingKey.THEME]: "",
     [api.SettingKey.ITEMS_ORDER]: "",
     [api.SettingKey.PROXY]: "",
+    [api.SettingKey.FETCH_OLD_ITEMS]: ""
   });
 
   const keyToText = (key: api.SettingKey) => {

--- a/src/styles/Feeds.css
+++ b/src/styles/Feeds.css
@@ -2,6 +2,10 @@ div.feeds-page form > input {
   width: 250px;
 }
 
+div.feeds-page form > span > input {
+  margin-left: .5rem;
+}
+
 div.feeds-page ul.feed-list {
   padding: 0;
   list-style: none;


### PR DESCRIPTION
### Changes
- You may no longer get old items when you subscribe to a feed.
- You don't have to enter an RSS/ATOM address when subscribing to a feed! Simply enter your main blog address or YouTube link etc and we'll subscribe you to the feed automatically.

### Related Issues
- #12 

### Comment
- Should we send a notification when a subscription fails or when we find and subscribe to an RSS/ATOM address? I would welcome some discussion on this.