### PR TITLE
hotfix: handle unexpected panic situations when fetching feeds

### DIFF
--- a/src-tauri/src/error.rs
+++ b/src-tauri/src/error.rs
@@ -17,6 +17,12 @@ pub enum Error {
     #[error("failed to parse syndication feed")]
     SyndicationParsingFailure,
 
+    #[error("failed to fetch feed: {0}")]
+    FetchFeedFailure(String),
+
+    #[error("failed to fetch feed items: {0}")]
+    FetchFeedItemsFailure(String),
+
     #[error("empty string")]
     EmptyString,
 


### PR DESCRIPTION
Hi.

I've noticed an unexpected error when fetching feeds after my contribution. You may remember the issue I mentioned in a previous PR, and I've fixed it. Below is the issue I was talking about.

![Screenshot 2024-02-11 at 22 23 34](https://github.com/parksb/collie/assets/38127960/7b2973a6-a156-4299-91d8-5d89384d3a5d)

The workaround is as follows
- Improved error handling: use the match syntax instead of unwrap() to return the appropriate error message when an error occurs, and use the Result type throughout the function to explicitly handle success and failure.