### PR TITLE
fall back on updated time if published_at not available

### DIFF
--- a/src-tauri/src/syndication.rs
+++ b/src-tauri/src/syndication.rs
@@ -57,7 +57,7 @@ pub fn fetch_feed_items(link: &str, proxy: Option<&str>) -> Result<Vec<RawItem>>
                     .map(atom_syndication::Content::value)
                     .filter(std::option::Option::is_some)
                     .map(|x| x.unwrap().to_string()),
-                published_at: x.published().map(|x| x.with_timezone(&Utc).fixed_offset()),
+                published_at: x.published().or(Some(x.updated())).map(|x| x.with_timezone(&Utc).fixed_offset()),
             })
             .collect()),
         Feed::RSS(rss) => Ok(rss


### PR DESCRIPTION
I found that one of my feeds `https://fasterthanli.me/index.xml` did not have a `published_at` field. Here we fallback on `updated`.